### PR TITLE
Include tgz and tbz2 extensions when checking downloads

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ GNURADIO_BRANCH=3.7.10.1
 # default os x path minus /usr/local/bin, which could have pollutants
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-EXTS="zip tar.gz tar.bz2 tar.xz"
+EXTS="zip tar.gz tgz tar.bz2 tbz2 tar.xz"
 
 SKIP_FETCH=true
 SKIP_AUTORECONF=


### PR DESCRIPTION
I noticed that cblas.tgz was getting re-downloaded, and then found that tgz and tbz2 may need to be added to EXTS.  (I preserved the order of EXTS to match the if/elif/elif/.../fi block in ```unpack()```.)