### PR TITLE
Python framework

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1547,7 +1547,8 @@ EXTRA_OPTS="\
   -DTHRIFT_INCLUDE_DIRS=${INSTALL_DIR}/usr/include \
   -DCPPUNIT_INCLUDE_DIRS=${INSTALL_DIR}/usr/include/cppunit \
   -DPYTHON_EXECUTABLE=$(which ${PYTHON}) \
-  -DPYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/2.7/Headers \
+  '-DCMAKE_C_FLAGS=-framework Python' \
+  '-DCMAKE_CXX_FLAGS=-framework Python' \
   -DSPHINX_EXECUTABLE=${INSTALL_DIR}/usr/bin/rst2html-2.7.py \
   -DGR_PYTHON_DIR=${INSTALL_DIR}/usr/share/gnuradio/python/site-packages \
   ${TMP_DIR}/${T} \

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ GNURADIO_BRANCH=3.7.10.1
 # default os x path minus /usr/local/bin, which could have pollutants
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
-EXTS="zip tar.gz tar.bz2 tar.xz"
+EXTS="zip tar.gz tgz tar.bz2 tbz2 tar.xz"
 
 SKIP_FETCH=true
 SKIP_AUTORECONF=


### PR DESCRIPTION
Rather than hard coding -I/Library/Frameworks/Python.framework/Versions/2.7/Headers when compiling gnuradio, specifying "-framework Python" will auto-search /Library or /System/Library.  On my system, Python 2.7 headers are under /System/Library/Frameworks/... instead of /Library/Frameworks/...

More details here:
https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPFrameworks/Tasks/IncludingFrameworks.html