### PR TITLE
run-grc tweaks and enhancements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1998,6 +1998,71 @@ mkdir -p ${CONTENTS_DIR} \
   <string>6.0</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>grc</string>
+        <string>GRC</string>
+        <string>grc.xml</string>
+        <string>GRC.XML</string>
+      </array>
+      <key>CFBundleTypeIconFile</key>
+      <string>gnuradio.icns</string>
+      <key>CFBundleTypeMIMETypes</key>
+      <array>
+        <string>application/gnuradio-grc</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>GNU Radio Companion Flow Graph</string>
+      <key>CFBundleTypeOSTypes</key>
+      <array>
+        <string>GRC </string>
+      </array>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSIsAppleDefaultForType</key>
+      <true />
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>org.gnuradio.grc</string>
+      </array>
+    </dict>
+  </array>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.xml</string>
+      </array>
+      <key>UTTypeDescription</key>
+      <string>GNU Radio Companion Flow Graph</string>
+      <key>UTTypeIconFile</key>
+      <string>gnuradio.icns</string>
+      <key>UTTypeIdentifier</key>
+      <string>org.gnuradio.grc</string>
+      <key>UTTypeReferenceURL</key>
+      <string>http://www.gnuradio.org/</string>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>com.apple.ostype</key>
+        <string>GRC </string>
+        <key>public.filename-extension</key>
+        <array>
+          <string>grc</string>
+          <string>GRC</string>
+          <string>grc.xml</string>
+          <string>GRC.XML</string>
+        </array>
+        <key>public.mime-type</key>
+        <array>
+          <string>application/gnuradio-grc</string>
+        </array>
+      </dict>
+    </dict>
+  </array>
 </dict>
 </plist>
 EOF

--- a/build.sh
+++ b/build.sh
@@ -1930,7 +1930,6 @@ EOF
   I installing run-grc script \
   && mkdir -p ${INSTALL_DIR}/usr/bin \
   && cat ${BUILD_DIR}/scripts/run-grc.sh \
-      | sed -e "s|@INSTALL_DIR@|${INSTALL_DIR}|g" \
       > ${INSTALL_DIR}/usr/bin/run-grc \
   && chmod +x ${INSTALL_DIR}/usr/bin/run-grc \
   || E "failed to install 'run-grc' script"

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -2,6 +2,4 @@
 
 source @INSTALL_DIR@/usr/bin/grenv.sh
 
-gnuradio-companion ${@} &
-
-exit 0
+exec gnuradio-companion ${@}

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -58,12 +58,22 @@ if command -v xset >/dev/null 2>&1 ; then
 	# While we wait, use osascript to tell the user what we're up to.
 	osascript -e 'display notification "Starting X server..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
 	if xset q >/dev/null 2>&1 ; then
-		osascript -e 'display notification "Starting GNU Radio Companion..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+		osascript \
+			-e 'on run(argv)' \
+			-e 'display notification ("exec gnuradio-companion " & item 1 of argv) with title "GNU Radio Companion" subtitle "Launching GNU Radio Companion..."' \
+			-e 'end run' \
+			-- "$*" \
+			> /dev/null 2>&1 || true
 	else
 		osascript -e 'display notification "Unable to verify running X server.  Will attempt anyway..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
 	fi
 else
-	osascript -e 'display notification "Starting GNU Radio Companion..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+	osascript \
+		-e 'on run(argv)' \
+		-e 'display notification ("exec gnuradio-companion " & item 1 of argv) with title "GNU Radio Companion" subtitle "Launching GNU Radio Companion..."' \
+		-e 'end run' \
+		-- "$*" \
+		> /dev/null 2>&1 || true
 fi
 
 ## Strip out the -psn_... argument added by the OS.

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -1,5 +1,32 @@
 #!/bin/sh
 
+set -e
+
+show_fail_message () {
+	osascript -e 'display notification "Failed to start GNU Radio Companion.\nDetail: '"$*"'" with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+	return 0
+}
+
+# If the exec fails for some reason, then our EXIT handler will get invoked.
+# At exit, run cleanup_script but let the exit status still be whatever the
+# shell was going to exit with:
+trap 'show_fail_message "exit status $?"' EXIT
+
+# If we get a signal such as SIGINT SIGQUIT or SIGTERM, then mask signal,
+# show_fail_message, restore default handler, and raise signal again to let it
+# propagate to whatever process started this script:
+trap '{ trap - EXIT ; trap "" INT  ; show_fail_message "received signal INT"  ; trap - INT  ; kill -s INT  $$ ; }' INT
+trap '{ trap - EXIT ; trap "" QUIT ; show_fail_message "received signal QUIT" ; trap - QUIT ; kill -s QUIT $$ ; }' QUIT
+trap '{ trap - EXIT ; trap "" TERM ; show_fail_message "received signal TERM" ; trap - TERM ; kill -s TERM $$ ; }' TERM
+# The leading "trap - EXIT" disables the EXIT signal handler or otherwise
+# show_fail_message gets called twice.
+
+# Uncomment one at a time to test each exit condition:
+#kill -s INT -- $$
+#kill -s QUIT -- $$
+#kill -s TERM -- $$
+#exit 2
+
 # Figure out where this script is located:
 case "$0" in
 	/*)
@@ -15,9 +42,36 @@ esac
 grenv_path="${argv0_path%/*}/grenv.sh"
 
 if ! test -e "${grenv_path}" ; then
+	osascript -e 'on run argv' -e 'display dialog ("Unable to find grenv.sh at " & item 1 of argv) buttons {"OK"} default button 1 with icon stop with title "GNU Radio Companion"' -e 'end run' "${grenv_path}" > /dev/null 2>&1 || true
 	printf 'Unable to find grenv.sh at %s\n' "${grenv_path}" 1>&2
 	exit 1
 fi
 . "${grenv_path}"
 
-exec gnuradio-companion "${@}"
+if command -v xset >/dev/null 2>&1 ; then
+	# If xset is available, then we'll use that to silently launch the X server.
+	# While we wait, use osascript to tell the user what we're up to.
+	osascript -e 'display notification "Starting X server..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+	if xset q >/dev/null 2>&1 ; then
+		osascript -e 'display notification "Starting GNU Radio Companion..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+	else
+		osascript -e 'display notification "Unable to verify running X server.  Will attempt anyway..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+	fi
+else
+	osascript -e 'display notification "Starting GNU Radio Companion..." with title "GNU Radio Companion"' > /dev/null 2>&1 || true
+fi
+
+## Strip out the -psn_... argument added by the OS.
+#if [ "x${1#-psn_}" != "x${1}" ]; then
+#	shift 1
+#fi
+
+# Prime the exit status with "( exit 127 ) || " in case exec fails.  Otherwise,
+# $? is 0 during trap EXIT.
+( exit 127 ) || exec gnuradio-companion "${@}"
+# Without the "trap ... EXIT", then we wouldn't need the "( exit 127 ) || ",
+# since the shell would automatically return the appropriate error number from
+# exec's failure.  Is this a glitch in bash since sh is symlinked to bash on my
+# system?  Note that exec can return other exit status beside 127, so this
+# stunt is suboptimal, but an optimally pedantic solution would require exec to
+# interact better wirth trap EXIT.

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -42,7 +42,12 @@ esac
 grenv_path="${argv0_path%/*}/grenv.sh"
 
 if ! test -e "${grenv_path}" ; then
-	osascript -e 'on run argv' -e 'display dialog ("Unable to find grenv.sh at " & item 1 of argv) buttons {"OK"} default button 1 with icon stop with title "GNU Radio Companion"' -e 'end run' "${grenv_path}" > /dev/null 2>&1 || true
+	osascript \
+		-e 'on run(argv)' \
+		-e 'display dialog ("Unable to find grenv.sh at " & item 1 of argv) buttons {"OK"} default button 1 with icon stop with title "GNU Radio Companion"' \
+		-e 'end run' \
+		-- "${grenv_path}" \
+		> /dev/null 2>&1 || true
 	printf 'Unable to find grenv.sh at %s\n' "${grenv_path}" 1>&2
 	exit 1
 fi

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
-. '@INSTALL_DIR@/usr/bin/grenv.sh'
+# Figure out where this script is located:
+case "$0" in
+	/*)
+		# $0 is absolute path since it starts with /
+		argv0_path="$0"
+		;;
+	*)
+		# Assume $0 is relative path:
+		argv0_path="$PWD/$0"
+		;;
+esac
+# This script is in GNURadio.app/Contents/MacOS/usr/bin with grenv.sh
+grenv_path="${argv0_path%/*}/grenv.sh"
+
+if ! test -e "${grenv_path}" ; then
+	printf 'Unable to find grenv.sh at %s\n' "${grenv_path}" 1>&2
+	exit 1
+fi
+. "${grenv_path}"
 
 exec gnuradio-companion "${@}"

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-source @INSTALL_DIR@/usr/bin/grenv.sh
+source '@INSTALL_DIR@/usr/bin/grenv.sh'
 
-exec gnuradio-companion ${@}
+exec gnuradio-companion "${@}"

--- a/scripts/run-grc.sh
+++ b/scripts/run-grc.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-source '@INSTALL_DIR@/usr/bin/grenv.sh'
+. '@INSTALL_DIR@/usr/bin/grenv.sh'
 
 exec gnuradio-companion "${@}"


### PR DESCRIPTION
This PR cleans up a few odds and ends such as
* cleanly handling spaces in input file names:
    ```sh
    ~/Applications/GNURadio.app/Contents/MacOS/usr/bin/run-grc "the test.grc"
    ```
    (precursor to figuring out how to associate .grc files in Finder with opening run-grc...)
* making the ```run-grc``` command no longer dependent on hard-coded INSTALL_DIR (for #13) so that one day users may put GNURadio.app in other locations beside ```/Applications```, such as in their ```$HOME/Applications```.
* as well as giving fast user-friendly feedback for issue #5:
    ![notification](https://cloud.githubusercontent.com/assets/4298582/26751304/f05fba52-47ea-11e7-9a18-e448df80e2fe.png)
    ![notification2](https://cloud.githubusercontent.com/assets/4298582/26751307/f40c94fe-47ea-11e7-94f2-2f2cea913f63.png)